### PR TITLE
android: Redirect stdout and stderr to logcat

### DIFF
--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -1,6 +1,8 @@
 #include <jni.h>
 #include <string>
 #include <cstdlib>
+#include <pthread.h>
+#include <unistd.h>
 #include <android/log.h>
 
 #include "node.h"
@@ -39,6 +41,61 @@ void rcv_message(char* msg) {
         env->CallStaticVoidMethod(cls2, m_sendMessage,java_msg);                      // call method
     }
   }
+}
+
+// Start threads to redirect stdout and stderr to logcat.
+int pipe_stdout[2];
+int pipe_stderr[2];
+pthread_t thread_stdout;
+pthread_t thread_stderr;
+const char *ADBTAG = "NODEJS-MOBILE";
+
+void *thread_stderr_func(void*) {
+    ssize_t redirect_size;
+    char buf[2048];
+    while((redirect_size = read(pipe_stderr[0], buf, sizeof buf - 1)) > 0) {
+        //__android_log will add a new line anyway.
+        if(buf[redirect_size - 1] == '\n')
+            --redirect_size;
+        buf[redirect_size] = 0;
+        __android_log_write(ANDROID_LOG_ERROR, ADBTAG, buf);
+    }
+    return 0;
+}
+
+void *thread_stdout_func(void*) {
+    ssize_t redirect_size;
+    char buf[2048];
+    while((redirect_size = read(pipe_stdout[0], buf, sizeof buf - 1)) > 0) {
+        //__android_log will add a new line anyway.
+        if(buf[redirect_size - 1] == '\n')
+            --redirect_size;
+        buf[redirect_size] = 0;
+        __android_log_write(ANDROID_LOG_INFO, ADBTAG, buf);
+    }
+    return 0;
+}
+
+int start_redirecting_stdout_stderr() {
+    //set stdout as unbuffered.
+    setvbuf(stdout, 0, _IONBF, 0);
+    pipe(pipe_stdout);
+    dup2(pipe_stdout[1], STDOUT_FILENO);
+
+    //set stderr as unbuffered.
+    setvbuf(stderr, 0, _IONBF, 0);
+    pipe(pipe_stderr);    
+    dup2(pipe_stderr[1], STDERR_FILENO);
+
+    if(pthread_create(&thread_stdout, 0, thread_stdout_func, 0) == -1)
+        return -1;
+    pthread_detach(thread_stdout);
+
+    if(pthread_create(&thread_stderr, 0, thread_stderr_func, 0) == -1)
+        return -1;
+    pthread_detach(thread_stderr);
+
+    return 0;
 }
 
 //node's libUV requires all arguments being on contiguous memory.
@@ -91,6 +148,11 @@ Java_com_janeasystems_rn_1nodejs_1mobile_RNNodeJsMobileModule_startNodeWithArgum
     rn_register_bridge_cb(&rcv_message);
 
     cacheEnvPointer=env;
+
+    //Start threads to show stdout and stderr in logcat.
+    if (start_redirecting_stdout_stderr()==-1) {
+        __android_log_write(ANDROID_LOG_ERROR, ADBTAG, "Couldn't start redirecting stdout and stderr to logcat.");
+    }
 
     //Start node, with argc and argv.
     return jint(callintoNode(argument_count,argv));


### PR DESCRIPTION
Starts threads to redirect `stdout` and `stderr` and show them in Android's `logcat`.

Ref: https://github.com/janeasystems/nodejs-mobile/issues/6