### PR TITLE
bridge: emit message event inside a setImmediate

### DIFF
--- a/install/resources/nodejs-modules/builtin_modules/rn-bridge/index.js
+++ b/install/resources/nodejs-modules/builtin_modules/rn-bridge/index.js
@@ -10,7 +10,9 @@ MyEmitter.prototype.send=function(msg) {
 const channel = new MyEmitter();
 
 var myListener = mybridgeaddon.registerListener( function(msg) {
-  channel.emit('message', msg);
+  setImmediate( () => {
+    channel.emit('message', msg);
+  });
 });
 
 exports.channel = channel;


### PR DESCRIPTION
Emit the bridge's message event inside a setImmediate, so listener code is called outside the `n-api` scope created when the bridge receives a call from the react-native application code.
This allows for promises started on the listeners to be resolved and causes errors to be recognized by the javascript engine instead of silently failing.

Ref: https://github.com/janeasystems/nodejs-mobile/issues/13
Ref: https://github.com/janeasystems/nodejs-mobile/issues/6