### PR TITLE
Using SDK Version variables from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
     }
 }
 
@@ -63,7 +63,7 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"
 }
 
 task CopyNodeProjectAssetsFolder (type:Sync) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,19 +5,27 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
     }
 }
 
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         externalNativeBuild {
@@ -30,20 +38,20 @@ android {
             abiFilters = project(":app").android.defaultConfig.ndk.abiFilters
         }
     }
-    
+
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"
         }
     }
-    
+
     sourceSets {
         main {
             jniLibs.srcDirs 'libnode/bin/'
         }
         main.assets.srcDirs += '../install/resources/nodejs-modules'
     }
-    
+
     lintOptions {
         abortOnError false
     }
@@ -54,7 +62,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }
 
 task CopyNodeProjectAssetsFolder (type:Sync) {


### PR DESCRIPTION
Instead of assuming the `compileSdkVersion`, `targetSdkVersion`, etc, read it from the root project.
Default `compileSdkVersion` and `targetSdkVersion` to the latest versions.

Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html
And the React Native team is already working on this:
https://github.com/facebook/react-native/pull/17741
https://github.com/facebook/react-native/issues/18095