### PR TITLE
adding podspec file for cocoapods based projects

### DIFF
--- a/RNNodeJsMobile.podspec
+++ b/RNNodeJsMobile.podspec
@@ -9,11 +9,17 @@ Pod::Spec.new do |s|
   s.homepage              = package['homepage']
   s.authors               = package['author']
   s.summary               = package['description']
-  s.source                = { :git => package['repository']['url'] }
-  s.source_files          = 'ios/*.{h,m,mm}'
-  s.source_files          = 'ios/**/**/*.{h}'
+  s.source                = { :git => 'https://github.com/jgtoriginal/RNNodeJsMobile.git', :tag => 'master' }
+  s.source_files          = [
+				'ios/*.{h,m,mm,hpp,cpp}', 
+				'ios/NodeMobile.framework/Headers/*.{h}', 
+				'ios/libnode/include/node/*.{h}', 
+				'ios/libnode/include/node/**/*.{h}', 
+				'ios/libRNNodeJsMobile.a'
+			    ]
   s.platform              = :ios, '8.0'
   s.static_framework      = true
   s.cocoapods_version     = ">= 1.2.0"
+  s.dependency            'AFNetworking', '~> 3.2.1'
   s.dependency            'React'
 end

--- a/nodejs-mobile-react-native.podspec
+++ b/nodejs-mobile-react-native.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name                  = package['name']
+  s.name                  = 'RNNodeJsMobile'
   s.version               = package['version'].sub('-beta', '')
   s.license               = { :type => 'MIT' }
   s.homepage              = package['homepage']

--- a/nodejs-mobile-react-native.podspec
+++ b/nodejs-mobile-react-native.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                  = package['name']
+  s.version               = package['version'].sub('-beta', '')
+  s.license               = { :type => 'MIT' }
+  s.homepage              = package['homepage']
+  s.authors               = package['author']
+  s.summary               = package['description']
+  s.source                = { :git => package['repository']['url'] }
+  s.source_files          = 'ios/*.{h,m,mm}'
+  s.source_files          = 'ios/**/**/*.{h}'
+  s.platform              = :ios, '8.0'
+  s.static_framework      = true
+  s.cocoapods_version     = ">= 1.2.0"
+  s.dependency            'React'
+end


### PR DESCRIPTION
It turns out that this wonderful library doesn't work properly with cocoapods.
Mainly due to linking the library out of the main Podfile.

So I wrote a podspec file that will be picked up by the Podfile of the projects that includes this module as dependency.

It basically solves the automation process of the following issue.

https://github.com/janeasystems/nodejs-mobile/issues/96