### PR TITLE
Updated path in module-postlink.js for android & ios core builds in version 0.59 of RN.

### DIFF
--- a/scripts/module-postlink.js
+++ b/scripts/module-postlink.js
@@ -2,8 +2,8 @@ var path = require('path');
 var fs = require('fs');
 var ncp = require('ncp');
 var xcode = require('xcode');
-const android = require('./../../../node_modules/react-native/local-cli/core/android');
-const ios = require('./../../../node_modules/react-native/local-cli/core/ios');
+const android = require('./../../../node_modules/@react-native-community/cli/build/core/android');
+const ios = require('./../../../node_modules/@react-native-community/cli/build/core/ios');
 
 function hostPackageDir(file) {
   var pathComponents = file.split(path.sep);


### PR DESCRIPTION
Version 0.59 of RN breaks module-postscript.js due to the new location of the ios & android core builds. This PR updates the path to the new location, resolving the issue. 