### PR TITLE
Use ReactModule annotation from react-native 0.58

### DIFF
--- a/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
+++ b/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
+import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableType;
@@ -25,6 +26,7 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.Semaphore;
 
+@ReactModule(name = "RNNodeJsMobile")
 public class RNNodeJsMobileModule extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
   private final ReactApplicationContext reactContext;


### PR DESCRIPTION
As react-native 0.58 [release notes mention](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#breaking-changes-), these native modules now need a Java annotation.

I noticed that without this change, a runtime crash occurs. 