### PR TITLE
plugin: update xcode to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "nodejs-mobile-react-native",
   "version": "0.4.3",
@@ -28,10 +27,10 @@
     "react-native": ">=0.52.0"
   },
   "dependencies": {
-    "nodejs-mobile-gyp": "^0.3.1",
-    "ncp": "^2.0.0",
     "mkdirp": "^0.5.1",
-    "xcode": "^0.9.3"
+    "ncp": "^2.0.0",
+    "nodejs-mobile-gyp": "^0.3.1",
+    "xcode": "^2.0.0"
   },
   "rnpm": {
     "commands": {


### PR DESCRIPTION
Updates `xcode` to 2.0.0. This uses the latest version of `plist`. Previous versions were [vulnerable](https://app.snyk.io/vuln/npm:plist:20180219) to a ReDoS and may be reported by dependency audit systems such as Snyk or `npm audit`.