### PR TITLE
Update paths for react v0.60.x

### DIFF
--- a/scripts/module-postlink.js
+++ b/scripts/module-postlink.js
@@ -5,7 +5,7 @@ var xcode = require('xcode');
 
 var android;
 try {
-  android = require('./../../../node_modules/@react-native-community/cli/build/tools/android');
+  android = require('./../../../node_modules/@react-native-community/cli-platform-android/build/index');
 } catch (ex) {
   // Older version of react-native, try to load cli from inside react-native.
   android = require('./../../../node_modules/react-native/local-cli/core/android');
@@ -13,7 +13,7 @@ try {
 
 var ios;
 try {
-  ios = require('./../../../node_modules/@react-native-community/cli/build/tools/ios');
+  ios = require('./../../../node_modules/@react-native-community/cli-platform-ios/build/index');
 } catch (ex) {
   // Older version of react-native, try to load cli from inside react-native.
   ios = require('./../../../node_modules/react-native/local-cli/core/ios');


### PR DESCRIPTION
Versions:
```
react-native-cli: 2.0.1
react-native: 0.60.5
```

I was getting these errors earlier when I ran `react-native link nodejs-mobile-react-native`:
```
Error: Cannot find module './../../../node_modules/react-native/local-cli/core/android'
Require stack:
- /XXXXXXXX/node_modules/nodejs-mobile-react-native/scripts/module-postlink.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:772:15)
    at Function.Module._load (internal/modules/cjs/loader.js:677:27)
    at Module.require (internal/modules/cjs/loader.js:830:19)
    at require (internal/modules/cjs/helpers.js:68:18)
    at Object.<anonymous> (/XXXXXXXX/node_modules/nodejs-mobile-react-native/scripts/module-postlink.js:11:13)
    at Module._compile (internal/modules/cjs/loader.js:936:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
    at Module.load (internal/modules/cjs/loader.js:790:32)
    at Function.Module._load (internal/modules/cjs/loader.js:703:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:999:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/XXXXXXX/node_modules/nodejs-mobile-react-native/scripts/module-postlink.js'
  ]
}
```

I updated the paths to work with these react native versions. Maybe best to have an alternative method to load libraries based on the user's react native version?